### PR TITLE
Use plugin framework tag to add the custom iOS framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,9 +37,7 @@
     	<framework src="CFNetwork.framework"/>
     	<framework src="SystemConfiguration.framework"/>
     	<framework src="AdSupport.framework"/>
-
-		<source-file framework="true" src="lib/ios/LeanPlum.framework/libLeanPlum.a"/>
-		<header-file src="lib/ios/LeanPlum.framework/Headers/LeanPlum.h"/>
+    	<framework src="lib/ios/LeanPlum.framework" custom="true" />
 
 		<header-file src="src/ios/CDVLeanPlum.h" />
 		<source-file src="src/ios/CDVLeanPlum.m" />

--- a/src/ios/CDVLeanPlum.m
+++ b/src/ios/CDVLeanPlum.m
@@ -1,5 +1,5 @@
 #import "CDVLeanPlum.h"
-#import "LeanPlum.h"
+#import <LeanPlum/LeanPlum.h>
 
 @implementation CDVLeanPlum
 


### PR DESCRIPTION
This will fix the failing iOS builds in AppBuilder when this plugin is used
