### PR TITLE
[iOS]Add support for Cordova 4.x.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -16,7 +16,7 @@ Although the object is in the global scope, it is not available until after the 
 
 You need to obtain the app ID, development and production keys to add the plugin in your app. Once done, use the following line to enable debugging in the following way:
 
-    LeanPlum.enableDebugging();
+    Leanplum.enableDebugging();
 
 
 Next, start LeanPlum in the following way:

--- a/src/ios/CDVLeanPlum.m
+++ b/src/ios/CDVLeanPlum.m
@@ -1,5 +1,6 @@
 #import "CDVLeanPlum.h"
 #import <LeanPlum/LeanPlum.h>
+#import <objc/message.h>
 
 @implementation CDVLeanPlum
 
@@ -128,8 +129,6 @@
 
 - (void)notificationReceived
 {
-    NSLog(@"Notification received");
-
     if (self.notificationMessage && self.callback)
     {
         NSMutableString *jsonStr = [NSMutableString stringWithString:@"{"];
@@ -138,14 +137,27 @@
 
         [jsonStr appendString:@"}"];
 
-        NSLog(@"Msg: %@", jsonStr);
-
         NSString * jsCallBack = [NSString stringWithFormat:@"%@(%@);", self.callback, jsonStr];
-        [self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
+
+        SEL stringByEvaluatingJavaScriptFromStringSEL = @selector(stringByEvaluatingJavaScriptFromString:);
+        SEL webViewEngineSEL = @selector(webViewEngine);
+        SEL evaluateJavaScriptCompletionHandlerSEL = @selector(evaluateJavaScript:completionHandler:);
+
+        if ([self respondsToSelector:webViewEngineSEL]) {
+            // Use the new CDVWebViewEngineProtocol protocol introduced in Cordova 4.0.
+            // See for more details: https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md
+            // Use objc_msgSend to silence 'undeclared selector' warning.
+            id webViewEngine = objc_msgSend(self, webViewEngineSEL);
+
+            if ([webViewEngine respondsToSelector:evaluateJavaScriptCompletionHandlerSEL]) {
+                objc_msgSend(webViewEngine, evaluateJavaScriptCompletionHandlerSEL, jsCallBack, nil);
+            }
+        } else if ([self.webView respondsToSelector:stringByEvaluatingJavaScriptFromStringSEL]) {
+            objc_msgSend(self.webView, stringByEvaluatingJavaScriptFromStringSEL, jsCallBack);
+        }
 
         self.notificationMessage = nil;
     }
-
 }
 
 -(void)parseDictionary:(NSDictionary *)inDictionary intoJSON:(NSMutableString *)jsonString


### PR DESCRIPTION
**Description:** 
Fix compiler error when building AB project (using Cordova v4.x or later) with latest plugin (v2.0.1).
- Add support for Cordova 4.x.

> Fix compiler error.
> Use the new CDVWebViewEngineProtocol protocol introduced in Cordova 4.0.
> See [API Changes in cordova-ios-4.0](https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md) for more details regarding API changes.
- Fix documentation typo.

> The plugin clobbers is 'Leanplum'.

**TeamPulse:** [[Plugins][iOS] iOS Build for Cordova 5.0 fails with Telerik Analytics plugin](http://teampulse.telerik.com/view#item/315412)
**Tests Report:** [MarketPluginTests Report](http://ice-qajenkins:8080/view/Samples+Plugins/job/CLI_Build_Marketplace_Combo_Plugins_LIN/138/HTML_Report_and_Logs/)
